### PR TITLE
Add row template for new rows

### DIFF
--- a/app/js/partyModal.js
+++ b/app/js/partyModal.js
@@ -3,10 +3,11 @@ const TokenSelector = require("./tokenSelector");
 const tokenSelector = new TokenSelector();
 const partyModal = function () {
 
+    const rowTemplate = $(".pcRow:nth-child(1)").clone();
 
     function addRow() {
 
-        var row = $(".pcRow:nth-child(1)").clone();
+        var row = rowTemplate.clone();
         row.attr("data-char_id", null);
         row.attr("data-token_to_save", null);
         var linkButton = row[0].querySelector(".link_button");


### PR DESCRIPTION
Using template instead of expecting to see a row on creating a new one will fix a bug with party being unable to create new rows after deleting all members.

Console output on attempting to create new row with an empty party list without a template:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'querySelector')
    at Object.addRow (app/js/partyModal.js:12)
    at HTMLButtonElement.onclick (index.html:712)
```