### PR TITLE
Added support for animated tokens (gifs and animated webp) 

### DIFF
--- a/app/js/dataaccess.js
+++ b/app/js/dataaccess.js
@@ -400,16 +400,11 @@ module.exports = (function () {
     async function saveToken(tokenId, currentPath, trim) {
         console.log("Saving token", tokenId, "trim:" + trim);
         var savePath = getNewTokenSavePath;
-        currentPath, tokenId;
         savePath = pathModule.join(defaultTokenPath, tokenId + ".webp");
-        let buffer = await sharp(currentPath)
-            .resize({
-                width: baseTokenSize,
-            })
-            .toFormat(TOKEN_FORMAT)
-            .toBuffer();
-        if (trim) await sharp(buffer).trim(0.5).toFile(pathModule.resolve(savePath));
-        else await sharp(buffer).toFile(pathModule.resolve(savePath));
+        let buffer = await sharp(currentPath, { animated: true })
+            .resize({width: baseTokenSize}).webp().toBuffer();
+        if (trim) await sharp(buffer, { animated: true }).trim(0.5).toFile(pathModule.resolve(savePath));
+        else await sharp(buffer, { animated: true }).toFile(pathModule.resolve(savePath));
     }
 
     function saveSettings(settings, callback) {

--- a/app/js/util.js
+++ b/app/js/util.js
@@ -261,7 +261,7 @@ module.exports = (function () {
             if (svg) {
                 return await dataAccess.base64(path);
             }
-            var shrp = sharp(path);
+            var shrp = sharp(path, { animated: true });
             var metadata = await shrp.metadata();
             var width = metadata.width;
             var height = metadata.height;
@@ -275,7 +275,7 @@ module.exports = (function () {
                 }
             }
 
-            var buffer = await shrp.toFormat("webp").toBuffer();
+            var buffer = await shrp.webp().toBuffer();
 
             return buffer.toString("base64");
         } catch (err) {


### PR DESCRIPTION
Turns out there are animated webps. Adding `{animated:true}` on each constructor of `sharp` seems to be enough for the app to create animated webps from gifs. The server and client both display animations.
#95 